### PR TITLE
Fix after kinematics_interface API break (v1.1.0 -> v1.2.0) 

### DIFF
--- a/.github/workflows/ci-jazzy.yml
+++ b/.github/workflows/ci-jazzy.yml
@@ -24,4 +24,4 @@ jobs:
       - uses: ros-tooling/action-ros-ci@v0.3
         with:
           target-ros2-distro: jazzy
-          # vcs-repo-file-url: ./dynamics_interface.repos
+          vcs-repo-file-url: ./dynamics_interface.repos

--- a/dynamics_interface.repos
+++ b/dynamics_interface.repos
@@ -1,0 +1,5 @@
+repositories:
+    external/ros-controls/kinematics_interface:
+        type: git
+        url: https://github.com/ros-controls/kinematics_interface.git
+        version: master

--- a/dynamics_interface_fd/include/dynamics_interface_fd/dynamics_interface_fd.hpp
+++ b/dynamics_interface_fd/include/dynamics_interface_fd/dynamics_interface_fd.hpp
@@ -53,9 +53,17 @@ public:
 
   virtual ~DynamicsInterfaceFd();
 
+  /**
+   * \brief Initialize plugin. This method must be called before any other.
+   * \param[in] robot_description robot URDF in string format
+   * \param[in] parameters_interface
+   * \param[in] param_namespace namespace for kinematics parameters - defaults to "kinematics"
+   * \return true if successful
+   */
   bool initialize(
+    const std::string & robot_description,
     std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface> parameters_interface,
-    const std::string & end_effector_name) override;
+    const std::string & param_namespace) override;
 
   bool calculate_link_transform(
     const Eigen::VectorXd & joint_pos, const std::string & link_name,

--- a/dynamics_interface_fd/src/dynamics_interface_fd.cpp
+++ b/dynamics_interface_fd/src/dynamics_interface_fd.cpp
@@ -101,7 +101,6 @@ bool DynamicsInterfaceFd::initialize(
   }
   std::string end_effector_name = end_effector_name_param.as_string();
 
-
   // create kinematic chain
   KDL::Tree robot_tree;
   kdl_parser::treeFromString(robot_description_local, robot_tree);
@@ -117,7 +116,6 @@ bool DynamicsInterfaceFd::initialize(
   {
     root_name_ = robot_tree.getRootSegment()->first;
   }
-
 
   if (!robot_tree.getChain(root_name_, end_effector_name, chain_))
   {

--- a/dynamics_interface_fd/src/dynamics_interface_fd.cpp
+++ b/dynamics_interface_fd/src/dynamics_interface_fd.cpp
@@ -76,7 +76,7 @@ bool DynamicsInterfaceFd::initialize(
     // If the robot_description input argument is empty, try to get the
     // robot_description from the node's parameters.
     auto robot_param = rclcpp::Parameter();
-    if (!parameters_interface->get_parameter(ns + "robot_description", robot_param))
+    if (!parameters_interface->get_parameter("robot_description", robot_param))
     {
       RCLCPP_ERROR(LOGGER, "parameter robot_description not set in kinematics_interface_kdl");
       return false;

--- a/dynamics_interface_fd/test/test_asset_omega6_description.hpp
+++ b/dynamics_interface_fd/test/test_asset_omega6_description.hpp
@@ -1,5 +1,19 @@
-#ifndef TEST_ASSET_OMEGA_6_DESCRIPTION_HPP_
-#define TEST_ASSET_OMEGA_6_DESCRIPTION_HPP_
+// Copyright 2024 ICUBE Laboratory, University of Strasbourg
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TEST_ASSET_OMEGA6_DESCRIPTION_HPP_
+#define TEST_ASSET_OMEGA6_DESCRIPTION_HPP_
 
 namespace ros2_control_test_assets
 {
@@ -159,4 +173,4 @@ const auto valid_omega3_urdf =
 
 }  // namespace ros2_control_test_assets
 
-#endif  // TEST_ASSET_OMEGA_6_DESCRIPTION_HPP_
+#endif  // TEST_ASSET_OMEGA6_DESCRIPTION_HPP_

--- a/dynamics_interface_fd/test/test_dynamics_interface_fd.cpp
+++ b/dynamics_interface_fd/test/test_dynamics_interface_fd.cpp
@@ -422,8 +422,7 @@ TEST_F(TestDynamicsFdPlugin, FD_plugin_no_robot_description)
   loadAlphaParameter();
   loadGravityParameter();
 
-  ASSERT_FALSE(
-    kyn_->initialize("", node_->get_node_parameters_interface(), "dynamics"));
+  ASSERT_FALSE(kyn_->initialize("", node_->get_node_parameters_interface(), "dynamics"));
 }
 
 TEST_F(TestDynamicsFdPlugin, FD_plugin_as_kinematics_interface_only)

--- a/dynamics_interface_fd/test/test_dynamics_interface_fd.cpp
+++ b/dynamics_interface_fd/test/test_dynamics_interface_fd.cpp
@@ -145,7 +145,8 @@ TEST_F(TestDynamicsFdPlugin, FD_plugin_function_with_omega6_urdf)
   loadAllParameters();
 
   // initialize the  plugin
-  ASSERT_TRUE(dyn_->initialize(node_->get_node_parameters_interface(), end_effector_));
+  auto robot_param = rclcpp::Parameter();
+  ASSERT_TRUE(node_->get_parameter("robot_description", robot_param));
   RCLCPP_INFO(node_->get_logger(), "Plugin instantiated successfully!");
 
   // publish inertia matrix
@@ -222,7 +223,8 @@ TEST_F(TestDynamicsFdPlugin, FD_plugin_function_with_omega3_urdf)
   loadGravityParameter();
 
   // initialize the  plugin
-  ASSERT_TRUE(dyn_->initialize(node_->get_node_parameters_interface(), end_effector_));
+  auto robot_param = rclcpp::Parameter();
+  ASSERT_TRUE(node_->get_parameter("robot_description", robot_param));
   RCLCPP_INFO(node_->get_logger(), "Plugin instantiated successfully!");
 
   // publish inertia matrix
@@ -294,7 +296,8 @@ TEST_F(TestDynamicsFdPlugin, FD_plugin_function_std_vector)
   loadAllParameters();
 
   // initialize the  plugin
-  ASSERT_TRUE(dyn_->initialize(node_->get_node_parameters_interface(), end_effector_));
+  auto robot_param = rclcpp::Parameter();
+  ASSERT_TRUE(node_->get_parameter("robot_description", robot_param));
 
   // publish inertia matrix
   Eigen::Matrix<double, 6, 6> mock_inertia = 2 * Eigen::Matrix<double, 6, 6>::Identity();
@@ -354,7 +357,8 @@ TEST_F(TestDynamicsFdPlugin, no_inertia_published)
   loadAllParameters();
 
   // initialize the  plugin
-  ASSERT_TRUE(dyn_->initialize(node_->get_node_parameters_interface(), end_effector_));
+  auto robot_param = rclcpp::Parameter();
+  ASSERT_TRUE(node_->get_parameter("robot_description", robot_param));
   RCLCPP_INFO(node_->get_logger(), "Plugin instantiated successfully!");
 
   // dummy joint position and velocity
@@ -372,8 +376,12 @@ TEST_F(TestDynamicsFdPlugin, incorrect_input_sizes)
   // load robot description and alpha to parameter server
   loadAllParameters();
 
-  // initialize the  plugin
-  ASSERT_TRUE(dyn_->initialize(node_->get_node_parameters_interface(), end_effector_));
+  auto robot_param = rclcpp::Parameter();
+  ASSERT_TRUE(node_->get_parameter("robot_description", robot_param));
+  auto robot_description_str = robot_param.as_string();
+
+  ASSERT_TRUE(
+    kyn_->initialize(robot_description_str, node_->get_node_parameters_interface(), "dynamics"));
 
   // define correct values
   Eigen::Matrix<double, Eigen::Dynamic, 1> pos =
@@ -413,7 +421,9 @@ TEST_F(TestDynamicsFdPlugin, FD_plugin_no_robot_description)
   // load alpha to parameter server
   loadAlphaParameter();
   loadGravityParameter();
-  ASSERT_FALSE(dyn_->initialize(node_->get_node_parameters_interface(), end_effector_));
+
+  ASSERT_FALSE(
+    kyn_->initialize("", node_->get_node_parameters_interface(), "dynamics"));
 }
 
 TEST_F(TestDynamicsFdPlugin, FD_plugin_as_kinematics_interface_only)
@@ -422,7 +432,14 @@ TEST_F(TestDynamicsFdPlugin, FD_plugin_as_kinematics_interface_only)
   loadAllParameters();
 
   // initialize the  plugin
-  ASSERT_TRUE(kyn_->initialize(node_->get_node_parameters_interface(), end_effector_));
+
+  // initialize the  plugin
+  auto robot_param = rclcpp::Parameter();
+  ASSERT_TRUE(node_->get_parameter("robot_description", robot_param));
+  auto robot_description_str = robot_param.as_string();
+
+  ASSERT_TRUE(
+    kyn_->initialize(robot_description_str, node_->get_node_parameters_interface(), "dynamics"));
 
   // dummy joint position and velocity
   Eigen::Matrix<double, Eigen::Dynamic, 1> pos =

--- a/dynamics_interface_kdl/include/dynamics_interface_kdl/dynamics_interface_kdl.hpp
+++ b/dynamics_interface_kdl/include/dynamics_interface_kdl/dynamics_interface_kdl.hpp
@@ -42,7 +42,6 @@ namespace dynamics_interface_kdl
 class DynamicsInterfaceKDL : public dynamics_interface::DynamicsInterface
 {
 public:
-
   /**
    * \brief Initialize plugin. This method must be called before any other.
    * \param[in] robot_description robot URDF in string format

--- a/dynamics_interface_kdl/include/dynamics_interface_kdl/dynamics_interface_kdl.hpp
+++ b/dynamics_interface_kdl/include/dynamics_interface_kdl/dynamics_interface_kdl.hpp
@@ -42,9 +42,18 @@ namespace dynamics_interface_kdl
 class DynamicsInterfaceKDL : public dynamics_interface::DynamicsInterface
 {
 public:
+
+  /**
+   * \brief Initialize plugin. This method must be called before any other.
+   * \param[in] robot_description robot URDF in string format
+   * \param[in] parameters_interface
+   * \param[in] param_namespace namespace for kinematics parameters - defaults to "kinematics"
+   * \return true if successful
+   */
   bool initialize(
+    const std::string & robot_description,
     std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface> parameters_interface,
-    const std::string & end_effector_name) override;
+    const std::string & param_namespace) override;
 
   bool calculate_link_transform(
     const Eigen::VectorXd & joint_pos, const std::string & link_name,

--- a/dynamics_interface_kdl/src/dynamics_interface_kdl.cpp
+++ b/dynamics_interface_kdl/src/dynamics_interface_kdl.cpp
@@ -30,7 +30,6 @@ bool DynamicsInterfaceKDL::initialize(
   // track initialization plugin
   initialized = true;
 
-
   // get parameters
   std::string ns = !param_namespace.empty() ? param_namespace + "." : "";
 
@@ -65,7 +64,6 @@ bool DynamicsInterfaceKDL::initialize(
   }
   std::string end_effector_name = end_effector_name_param.as_string();
 
-
   // create kinematic chain
   KDL::Tree robot_tree;
   kdl_parser::treeFromString(robot_description_local, robot_tree);
@@ -81,7 +79,6 @@ bool DynamicsInterfaceKDL::initialize(
   {
     root_name_ = robot_tree.getRootSegment()->first;
   }
-
 
   if (!robot_tree.getChain(root_name_, end_effector_name, chain_))
   {
@@ -104,7 +101,6 @@ bool DynamicsInterfaceKDL::initialize(
   {
     link_name_map_[chain_.getSegment(i).getName()] = i + 1;
   }
-
 
   // get gravity vector in base frame
   auto gravity_param = rclcpp::Parameter();

--- a/dynamics_interface_kdl/src/dynamics_interface_kdl.cpp
+++ b/dynamics_interface_kdl/src/dynamics_interface_kdl.cpp
@@ -40,7 +40,7 @@ bool DynamicsInterfaceKDL::initialize(
     // If the robot_description input argument is empty, try to get the
     // robot_description from the node's parameters.
     auto robot_param = rclcpp::Parameter();
-    if (!parameters_interface->get_parameter(ns + "robot_description", robot_param))
+    if (!parameters_interface->get_parameter("robot_description", robot_param))
     {
       RCLCPP_ERROR(LOGGER, "parameter robot_description not set in kinematics_interface_kdl");
       return false;

--- a/dynamics_interface_kdl/src/dynamics_interface_kdl.cpp
+++ b/dynamics_interface_kdl/src/dynamics_interface_kdl.cpp
@@ -23,38 +23,58 @@ namespace dynamics_interface_kdl
 rclcpp::Logger LOGGER = rclcpp::get_logger("dynamics_interface_kdl");
 
 bool DynamicsInterfaceKDL::initialize(
+  const std::string & robot_description,
   std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface> parameters_interface,
-  const std::string & end_effector_name)
+  const std::string & param_namespace)
 {
   // track initialization plugin
   initialized = true;
 
-  // get robot description
-  auto robot_param = rclcpp::Parameter();
-  if (!parameters_interface->get_parameter("robot_description", robot_param))
+
+  // get parameters
+  std::string ns = !param_namespace.empty() ? param_namespace + "." : "";
+
+  std::string robot_description_local;
+  if (robot_description.empty())
   {
-    RCLCPP_ERROR(LOGGER, "parameter robot_description not set");
+    // If the robot_description input argument is empty, try to get the
+    // robot_description from the node's parameters.
+    auto robot_param = rclcpp::Parameter();
+    if (!parameters_interface->get_parameter(ns + "robot_description", robot_param))
+    {
+      RCLCPP_ERROR(LOGGER, "parameter robot_description not set in kinematics_interface_kdl");
+      return false;
+    }
+    robot_description_local = robot_param.as_string();
+  }
+  else
+  {
+    robot_description_local = robot_description;
+  }
+
+  // get end-effector name
+  auto end_effector_name_param = rclcpp::Parameter("tip");
+  if (parameters_interface->has_parameter(ns + "tip"))
+  {
+    parameters_interface->get_parameter(ns + "tip", end_effector_name_param);
+  }
+  else
+  {
+    RCLCPP_ERROR(LOGGER, "Failed to find end effector name parameter [tip].");
     return false;
   }
-  auto robot_description = robot_param.as_string();
+  std::string end_effector_name = end_effector_name_param.as_string();
 
-  // get alpha damping term
-  auto alpha_param = rclcpp::Parameter("dynamics.alpha", 0.000005);
-  if (parameters_interface->has_parameter("dynamics.alpha"))
-  {
-    parameters_interface->get_parameter("dynamics.alpha", alpha_param);
-  }
-  alpha = alpha_param.as_double();
 
   // create kinematic chain
   KDL::Tree robot_tree;
-  kdl_parser::treeFromString(robot_description, robot_tree);
+  kdl_parser::treeFromString(robot_description_local, robot_tree);
 
   // get root name
   auto base_param = rclcpp::Parameter();
-  if (parameters_interface->has_parameter("dynamics.base"))
+  if (parameters_interface->has_parameter(ns + "base"))
   {
-    parameters_interface->get_parameter("dynamics.base", base_param);
+    parameters_interface->get_parameter(ns + "base", base_param);
     root_name_ = base_param.as_string();
   }
   else
@@ -62,11 +82,35 @@ bool DynamicsInterfaceKDL::initialize(
     root_name_ = robot_tree.getRootSegment()->first;
   }
 
+
+  if (!robot_tree.getChain(root_name_, end_effector_name, chain_))
+  {
+    RCLCPP_ERROR(
+      LOGGER, "failed to find chain from robot root %s to end effector %s", root_name_.c_str(),
+      end_effector_name.c_str());
+    return false;
+  }
+
+  if (!robot_tree.getChain(root_name_, end_effector_name, chain_))
+  {
+    RCLCPP_ERROR(
+      LOGGER, "failed to find chain from robot root %s to end effector %s", root_name_.c_str(),
+      end_effector_name.c_str());
+    return false;
+  }
+
+  // create map from link names to their index
+  for (size_t i = 0; i < chain_.getNrOfSegments(); ++i)
+  {
+    link_name_map_[chain_.getSegment(i).getName()] = i + 1;
+  }
+
+
   // get gravity vector in base frame
   auto gravity_param = rclcpp::Parameter();
-  if (parameters_interface->has_parameter("dynamics.gravity"))
+  if (parameters_interface->has_parameter(ns + "gravity"))
   {
-    parameters_interface->get_parameter("dynamics.gravity", gravity_param);
+    parameters_interface->get_parameter(ns + "gravity", gravity_param);
     std::vector<double> gravity_vec = gravity_param.as_double_array();
     if (gravity_vec.size() != 3)
     {
@@ -92,20 +136,6 @@ bool DynamicsInterfaceKDL::initialize(
       LOGGER, "Gravity set to %f %f %f w.r.t. base frame '%s'.",
       gravity_in_base_frame_[0], gravity_in_base_frame_[1], gravity_in_base_frame_[2], root_name_.c_str());
     */
-  }
-
-  if (!robot_tree.getChain(root_name_, end_effector_name, chain_))
-  {
-    RCLCPP_ERROR(
-      LOGGER, "failed to find chain from robot root %s to end effector %s", root_name_.c_str(),
-      end_effector_name.c_str());
-    return false;
-  }
-
-  // create map from link names to their index
-  for (size_t i = 0; i < chain_.getNrOfSegments(); ++i)
-  {
-    link_name_map_[chain_.getSegment(i).getName()] = i + 1;
   }
 
   // allocate dynamics memory

--- a/dynamics_interface_kdl/test/test_dynamics_interface_kdl.cpp
+++ b/dynamics_interface_kdl/test/test_dynamics_interface_kdl.cpp
@@ -100,7 +100,15 @@ TEST_F(TestKDLPlugin, KDL_plugin_function)
   loadAllParameters();
 
   // initialize the  plugin
-  ASSERT_TRUE(dyn_->initialize(node_->get_node_parameters_interface(), end_effector_));
+  auto robot_param = rclcpp::Parameter();
+  if (!node_->get_parameter("robot_description", robot_param))
+  {
+    RCLCPP_ERROR(LOGGER, "parameter robot_description not set in kinematics_interface_kdl");
+    return false;
+  }
+  auto robot_description_str = robot_param.as_string();
+  ASSERT_TRUE(
+    kyn_->initialize(robot_description_str, node_->get_node_parameters_interface(), "dynamics"));
 
   // dummy joint position and velocity
   Eigen::Matrix<double, Eigen::Dynamic, 1> pos = Eigen::Matrix<double, 2, 1>::Zero();
@@ -152,7 +160,15 @@ TEST_F(TestKDLPlugin, KDL_plugin_function_std_vector)
   loadAllParameters();
 
   // initialize the  plugin
-  ASSERT_TRUE(dyn_->initialize(node_->get_node_parameters_interface(), end_effector_));
+  auto robot_param = rclcpp::Parameter();
+  if (!node_->get_parameter("robot_description", robot_param))
+  {
+    RCLCPP_ERROR(LOGGER, "parameter robot_description not set in kinematics_interface_kdl");
+    return false;
+  }
+  auto robot_description_str = robot_param.as_string();
+  ASSERT_TRUE(
+    kyn_->initialize(robot_description_str, node_->get_node_parameters_interface(), "dynamics"));
 
   // calculate end effector transform
   std::vector<double> pos = {0, 0};
@@ -202,7 +218,15 @@ TEST_F(TestKDLPlugin, incorrect_input_sizes)
   loadAllParameters();
 
   // initialize the  plugin
-  ASSERT_TRUE(dyn_->initialize(node_->get_node_parameters_interface(), end_effector_));
+  auto robot_param = rclcpp::Parameter();
+  if (!node_->get_parameter("robot_description", robot_param))
+  {
+    RCLCPP_ERROR(LOGGER, "parameter robot_description not set in kinematics_interface_kdl");
+    return false;
+  }
+  auto robot_description_str = robot_param.as_string();
+  ASSERT_TRUE(
+    kyn_->initialize(robot_description_str, node_->get_node_parameters_interface(), "dynamics"));
 
   // define correct values
   Eigen::Matrix<double, Eigen::Dynamic, 1> pos = Eigen::Matrix<double, 2, 1>::Zero();
@@ -240,7 +264,10 @@ TEST_F(TestKDLPlugin, KDL_plugin_no_robot_description)
   // load alpha to parameter server
   loadAlphaParameter();
   loadGravityParameter();
-  ASSERT_FALSE(dyn_->initialize(node_->get_node_parameters_interface(), end_effector_));
+
+  // initialize the  plugin
+  auto robot_description_str = robot_param.as_string();
+  ASSERT_TRUE(kyn_->initialize("", node_->get_node_parameters_interface(), "dynamics"));
 }
 
 TEST_F(TestKDLPlugin, KDL_plugin_no_gravity)
@@ -248,7 +275,17 @@ TEST_F(TestKDLPlugin, KDL_plugin_no_gravity)
   // load alpha to parameter server
   loadURDFParameter();
   loadAlphaParameter();
-  ASSERT_FALSE(dyn_->initialize(node_->get_node_parameters_interface(), end_effector_));
+
+  // initialize the  plugin
+  auto robot_param = rclcpp::Parameter();
+  if (!node_->get_parameter("robot_description", robot_param))
+  {
+    RCLCPP_ERROR(LOGGER, "parameter robot_description not set in kinematics_interface_kdl");
+    return false;
+  }
+  auto robot_description_str = robot_param.as_string();
+  ASSERT_TRUE(
+    kyn_->initialize(robot_description_str, node_->get_node_parameters_interface(), "dynamics"));
 }
 
 TEST_F(TestKDLPlugin, KDL_plugin_as_kinematics_interface_only)
@@ -257,7 +294,15 @@ TEST_F(TestKDLPlugin, KDL_plugin_as_kinematics_interface_only)
   loadAllParameters();
 
   // initialize the  plugin
-  ASSERT_TRUE(kyn_->initialize(node_->get_node_parameters_interface(), end_effector_));
+  auto robot_param = rclcpp::Parameter();
+  if (!node_->get_parameter("robot_description", robot_param))
+  {
+    RCLCPP_ERROR(LOGGER, "parameter robot_description not set in kinematics_interface_kdl");
+    return false;
+  }
+  auto robot_description_str = robot_param.as_string();
+  ASSERT_TRUE(
+    kyn_->initialize(robot_description_str, node_->get_node_parameters_interface(), "dynamics"));
 
   // dummy joint position and velocity
   Eigen::Matrix<double, Eigen::Dynamic, 1> pos = Eigen::Matrix<double, 2, 1>::Zero();

--- a/dynamics_interface_kdl/test/test_dynamics_interface_kdl.cpp
+++ b/dynamics_interface_kdl/test/test_dynamics_interface_kdl.cpp
@@ -101,12 +101,9 @@ TEST_F(TestKDLPlugin, KDL_plugin_function)
 
   // initialize the  plugin
   auto robot_param = rclcpp::Parameter();
-  if (!node_->get_parameter("robot_description", robot_param))
-  {
-    RCLCPP_ERROR(LOGGER, "parameter robot_description not set in kinematics_interface_kdl");
-    return false;
-  }
+  ASSERT_TRUE(node_->get_parameter("robot_description", robot_param));
   auto robot_description_str = robot_param.as_string();
+
   ASSERT_TRUE(
     kyn_->initialize(robot_description_str, node_->get_node_parameters_interface(), "dynamics"));
 
@@ -161,11 +158,8 @@ TEST_F(TestKDLPlugin, KDL_plugin_function_std_vector)
 
   // initialize the  plugin
   auto robot_param = rclcpp::Parameter();
-  if (!node_->get_parameter("robot_description", robot_param))
-  {
-    RCLCPP_ERROR(LOGGER, "parameter robot_description not set in kinematics_interface_kdl");
-    return false;
-  }
+  ASSERT_TRUE(node_->get_parameter("robot_description", robot_param));
+
   auto robot_description_str = robot_param.as_string();
   ASSERT_TRUE(
     kyn_->initialize(robot_description_str, node_->get_node_parameters_interface(), "dynamics"));
@@ -219,12 +213,9 @@ TEST_F(TestKDLPlugin, incorrect_input_sizes)
 
   // initialize the  plugin
   auto robot_param = rclcpp::Parameter();
-  if (!node_->get_parameter("robot_description", robot_param))
-  {
-    RCLCPP_ERROR(LOGGER, "parameter robot_description not set in kinematics_interface_kdl");
-    return false;
-  }
+  ASSERT_TRUE(node_->get_parameter("robot_description", robot_param));
   auto robot_description_str = robot_param.as_string();
+
   ASSERT_TRUE(
     kyn_->initialize(robot_description_str, node_->get_node_parameters_interface(), "dynamics"));
 
@@ -266,7 +257,8 @@ TEST_F(TestKDLPlugin, KDL_plugin_no_robot_description)
   loadGravityParameter();
 
   // initialize the  plugin
-  auto robot_description_str = robot_param.as_string();
+  auto robot_param = rclcpp::Parameter();
+  ASSERT_TRUE(node_->get_parameter("robot_description", robot_param));
   ASSERT_TRUE(kyn_->initialize("", node_->get_node_parameters_interface(), "dynamics"));
 }
 
@@ -278,12 +270,9 @@ TEST_F(TestKDLPlugin, KDL_plugin_no_gravity)
 
   // initialize the  plugin
   auto robot_param = rclcpp::Parameter();
-  if (!node_->get_parameter("robot_description", robot_param))
-  {
-    RCLCPP_ERROR(LOGGER, "parameter robot_description not set in kinematics_interface_kdl");
-    return false;
-  }
+  ASSERT_TRUE(node_->get_parameter("robot_description", robot_param));
   auto robot_description_str = robot_param.as_string();
+
   ASSERT_TRUE(
     kyn_->initialize(robot_description_str, node_->get_node_parameters_interface(), "dynamics"));
 }
@@ -295,11 +284,7 @@ TEST_F(TestKDLPlugin, KDL_plugin_as_kinematics_interface_only)
 
   // initialize the  plugin
   auto robot_param = rclcpp::Parameter();
-  if (!node_->get_parameter("robot_description", robot_param))
-  {
-    RCLCPP_ERROR(LOGGER, "parameter robot_description not set in kinematics_interface_kdl");
-    return false;
-  }
+  ASSERT_TRUE(node_->get_parameter("robot_description", robot_param));
   auto robot_description_str = robot_param.as_string();
   ASSERT_TRUE(
     kyn_->initialize(robot_description_str, node_->get_node_parameters_interface(), "dynamics"));


### PR DESCRIPTION
Fix after `kinematics_interface` API changes to support robot description (see [issue #83](https://github.com/ros-controls/kinematics_interface/issues/83) and [PR #66](https://github.com/ros-controls/kinematics_interface/pull/66)).